### PR TITLE
Add buttonmap and topology

### DIFF
--- a/game.libretro.a5200/addon.xml.in
+++ b/game.libretro.a5200/addon.xml.in
@@ -5,6 +5,7 @@
 		provider-name="Petr Stehlik, zx81, Alekmaul, wavemotion-dave">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
+		<import addon="game.controller.atari.5200" version="1.0.32"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.a5200/addon.xml.in
+++ b/game.libretro.a5200/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="game.libretro.a5200"
 		name="Atari - 5200 (a5200)"
-		version="2.0.2.15"
+		version="2.0.2.16"
 		provider-name="Petr Stehlik, zx81, Alekmaul, wavemotion-dave">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>

--- a/game.libretro.a5200/resources/buttonmap.xml
+++ b/game.libretro.a5200/resources/buttonmap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<buttonmap version="2">
+    <controller id="game.controller.atari.5200" type="RETRO_DEVICE_JOYPAD">
+        <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+        <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+        <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+        <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+        <feature name="fire1" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
+        <feature name="fire2" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
+        <feature name="pound" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
+        <feature name="star" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
+        <feature name="num0" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
+        <feature name="num1" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
+        <feature name="num5" mapto="RETRO_DEVICE_ID_JOYPAD_R3"/>
+        <feature name="togglevkbd" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
+        <feature name="num3" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
+        <feature name="num7" mapto="RETRO_DEVICE_ID_JOYPAD_L3"/>
+        <feature name="pause" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+        <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
+    </controller>
+</buttonmap>

--- a/game.libretro.a5200/resources/topology.xml
+++ b/game.libretro.a5200/resources/topology.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<logicaltopology>
+  <port type="controller" id="1">
+    <accepts controller="game.controller.atari.5200"/>
+  </port>
+  <port type="controller" id="2">
+    <accepts controller="game.controller.atari.5200"/>
+  </port>
+</logicaltopology>


### PR DESCRIPTION
## Description

This PR adds a buttonmap and topology file for the Atari 5200 controller, which was updated in https://github.com/kodi-game/controller-topology-project/pull/292 for the atari800 buttonmap.

a5200 uses the same buttons as atari800, but the retropad mappings are different for most buttons.

Data comes from source:

* https://github.com/libretro/a5200/blob/master/libretro/libretro.c

## How has this been tested?

Testing in progress.